### PR TITLE
INPUT: made check_response case insensitive

### DIFF
--- a/derivative_dungeon.py
+++ b/derivative_dungeon.py
@@ -19,6 +19,7 @@ class derivative_dungeon:
         self.current_level._is_cleared = True
         self.has_key = False
         self.game_over = False
+        self.bad_input = False
         self.difficulty_counter = 1
         self.enemy_builder = EnemyBuilder()
 
@@ -53,12 +54,28 @@ class derivative_dungeon:
         Args:
             response (String): room user wants to travel to.
         """
-        while response not in self.current_level.connected_rooms:
+
+        for location in self.current_level.connected_names:
+            if response.lower() != location.lower():
+                self.bad_input = True
+            else:  
+                self.bad_input = False
+                response = location
+                break
+
+        while self.bad_input:
             print("\nNot quite. Please enter a connected room name.")
             print(f"Remember, you can only travel to...")
             for connected_name in self.current_level.connected_names:
                 print("\t" + connected_name)
             response = input("Make sure you enter it exactly as you see: ")
+
+            for location in self.current_level.connected_names:
+                if response.lower() == location.lower():
+                    response = location
+                    self.bad_input = False
+                    break
+
 
         self.move_user(response)
 


### PR DESCRIPTION
I edited the check_response method to work as case insensitive. The user response is set to lowercase and compared to the key (name) of the rooms connected to the current room the player is in. which is also set to lowercase. If the values are the same, the response is updated to contain the room's original name state, and then the player is moved. If it fails the comparison, it goes to the while loop, where until the wrong input has been changed, the player will be prompted to input again, and the response will be compared to the locations connected to the room again. 